### PR TITLE
Fix Replace `&#39;` and `&amp;` in News Titles

### DIFF
--- a/scenes/NewsFeed.gd
+++ b/scenes/NewsFeed.gd
@@ -136,7 +136,7 @@ func _get_news(data, avatars) -> Array:
 		var parsed_item = {}
 		parsed_item["image"] = post["image"]
 		parsed_item["contents"] = post["description"].replace("&#39;", "'").replace("&amp;", "&") # manually parse some html entieties. Parsing them all would probably be overkill
-		parsed_item["title"] = post["title"]
+		parsed_item["title"] = post["title"].replace("&#39;", "'").replace("&amp;", "&")
 		parsed_item["author"] = post["dc:creator"]
 		parsed_item["avatar"] = BASE_URL + avatars[post["dc:creator"]]
 		


### PR DESCRIPTION
This is just a small oversight from the original PR I made and I noticed due to the one of the latest Godot updates where they used a & symbol in the title