### PR TITLE
Prevent crash on mac

### DIFF
--- a/scenes/UIScale.gd
+++ b/scenes/UIScale.gd
@@ -26,7 +26,9 @@ func _rescale_ui(scale: float):
 		return
 	get_tree().set_screen_stretch(stretch_mode, stretch_aspect, Vector2.ZERO, scale)
 	OS.window_size = base_window_size * scale
+	$SpinBox.editable = false
 	OS.center_window()
+	$SpinBox.editable = true
 
 
 func _on_SpinBox_value_changed(value):


### PR DESCRIPTION
fixed #50 

Prevent crashes during window resizing on mac.
Because the value_changed is called many times in one SpinBox button click on mac.

The godot4 branch is fine as is.