### PR TITLE
Project background color

### DIFF
--- a/project.godot
+++ b/project.godot
@@ -26,7 +26,7 @@ run/main_scene="res://scenes/Main.tscn"
 run/low_processor_mode=true
 boot_splash/image="res://splash.png"
 boot_splash/fullsize=false
-boot_splash/bg_color=Color( 1, 1, 1, 1 )
+boot_splash/bg_color=Color( 0.0784314, 0.0784314, 0.0784314, 1 )
 config/icon="res://icon.png"
 config/windows_native_icon="res://windows_icon.ico"
 


### PR DESCRIPTION
Changed the project background color to #141414 like the normal background color of the program when running in dark mode. Getting blinded all the time for 1 second and think it looks better, even when you use light mode. Maybe change the default theme to dark mode overall?

Couldn't find a proper solution to automatically save the background color for next startup if theme changed