### PR TITLE
Skip download when version is already installed

### DIFF
--- a/scenes/VersionSelect.gd
+++ b/scenes/VersionSelect.gd
@@ -423,14 +423,26 @@ func _on_Refresh_pressed():
 func _on_Download_pressed():
 	if selected == -1:
 		return false
-	
+
+	var _selection = filtered_db_view[selected]
+
+	# Skip if this version is already in the installed list
+	var current_config = Globals.read_config()
+	for existing in current_config.versions:
+		if existing.name == _selection.name:
+			download_button.disabled = true
+			download_button.text = "Already installed"
+			yield(get_tree().create_timer(1.5), "timeout")
+			download_button.text = "Download"
+			download_button.disabled = false
+			return
+
 	is_downloading = true
 	emit_signal("download_started")
 	# Make sure the directory exists
 	var dir = Directory.new()
 	dir.make_dir("user://versions/")
-	
-	var _selection = filtered_db_view[selected]
+
 	download_button.disabled = true
 	
 	# TODO: make it work with other platforms


### PR DESCRIPTION
## Summary
- Re-clicking **Download** on a Godot release already in the installed list produced a duplicate row, because `_on_Download_pressed` in `scenes/VersionSelect.gd` never checked `config.versions` before downloading and appending.
- Added an early guard at the top of `_on_Download_pressed`: if the selected release's `name` already appears in `config.versions`, the Download button briefly flashes `Already installed` and the function returns — no network call, no `config.versions.append`.
- Match key is `name` (e.g. `Godot_v4.1.1-stable`), which is the value `_add_version` already stores, so download-time and installed-list identifiers stay in sync.

## Test plan
- [ ] Open `scenes/Main.tscn` in Godot 3.x and download a version not yet installed — single entry appears.
- [ ] Without restarting, pick the same version from the dropdown and click **Download** again — button flashes `Already installed`, no duplicate appears, no `Downloading…/Extracting..` text shown.
- [ ] Pick a different uninstalled version and download — succeeds normally (no false positive).
- [ ] Right-click an installed entry → **Delete**, then re-download the same version — succeeds normally (the guard no longer matches).
- [ ] Inspect `user://config.json` and confirm `versions` contains exactly one entry per `name`.
